### PR TITLE
Created a new parameter to dowload articles by pre configured search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ Configuration options available in the [config file](config.json)
 | allowImages             | boolean  | Whether to add images linked in article in the ebook  |
 | outputFileName          | string   | Ebook file name                                       |
 | maxArticleCount         | number   | Number of articles to fetch                           |
+  searchQuery             | string   | Valid query for article search, def: "sort:saved-asc" |
 | ignoredLabels           | string[] | List of labels to exclude from the ebook              |
 | ignoredLinks            | string[] | List of urls to exclude from the ebook                |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Configuration options available in the [config file](config.json)
 | allowImages             | boolean  | Whether to add images linked in article in the ebook  |
 | outputFileName          | string   | Ebook file name                                       |
 | maxArticleCount         | number   | Number of articles to fetch                           |
-  searchQuery             | string   | Valid query for article search, def: "sort:saved-asc" |
+| searchQuery             | string   | Valid query for article search, default: "sort:saved-desc". Change it to "sort:saved-asc" for fetching oldest articles first |
 | ignoredLabels           | string[] | List of labels to exclude from the ebook              |
 | ignoredLinks            | string[] | List of urls to exclude from the ebook                |

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
   "allowImages": true,
   "outputFileName": "output.epub",
   "maxArticleCount": 15,
-  "searchQuery": "sort:saved-asc",
+  "searchQuery": "sort:saved-desc",
   "ignoredLabels": ["pdf"],
   "ignoredLinks": ["https://www.youtu", "https://youtu"]
 }

--- a/config.json
+++ b/config.json
@@ -9,7 +9,8 @@
   "addArticleLinkInContent": true,
   "allowImages": true,
   "outputFileName": "output.epub",
-  "maxArticleCount": 100,
+  "maxArticleCount": 15,
+  "searchQuery": "sort:saved-asc",
   "ignoredLabels": ["pdf"],
   "ignoredLinks": ["https://www.youtu", "https://youtu"]
 }

--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,7 @@ async function checkForUpdates() {
 async function getUnreadArticles() {
   const query = gql`
     {
-      search(first: ${config.maxArticleCount}) {
+      search(query: "${config.searchQuery}", first: ${config.maxArticleCount}) {
         ... on SearchSuccess {
           edges {
             cursor


### PR DESCRIPTION
I have created [this issue](https://github.com/agrmohit/omnivore-epub/issues/2) and while I'm not a JS programmer, apparently typescript is not that hard :-)

So I have added a new `searchQuery` parameter (in `config.json`, `main.ts`, and in the README) that defaults to `sort:saved-asc` to allow donwloading the articles FIFO style.

I've also modified the `maxArticleCount` default value from 100 to 15 in `config.json` because 100 articles (especially with images) would result in a huge epub file.